### PR TITLE
pyacmecapture: first version

### DIFF
--- a/pyacmecapture/iioacmecape.py
+++ b/pyacmecapture/iioacmecape.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+""" Baylibre's ACME Cape Abstraction class
+
+Baylibre's ACME Cape Abstraction class.
+
+Inspired by work done on the "iio-capture" tool done by:
+    - Paul Cercueil <paul.cercueil@analog.com>,
+and the work done on "pyacmegraph" tool done by:
+    - Sebastien Jan <sjan@baylibre.com>.
+"""
+
+from __future__ import print_function
+import iio
+import xmlrpclib
+import traceback
+from mltrace import MLTrace
+from ping import ping
+from iioacmeprobe import IIOAcmeProbe
+
+
+__app_name__ = "IIO ACME Cape Python Library"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018, Baylibre SAS"
+__date__ = "2018/03/01"
+__author__ = "Patrick Titiano"
+__email__ =  "ptitiano@baylibre.com"
+__contact__ = "ptitiano@baylibre.com"
+__maintainer__ = "Patrick Titiano"
+__status__ = "Development"
+__version__ = "0.1"
+__deprecated__ = False
+
+
+class IIOAcmeCape():
+    def __init__(self, ip, verbose_level):
+        self._ip = ip
+        self._verbose_level = verbose_level
+        self._trace = MLTrace(verbose_level, "ACME Cape")
+        self._iioctx = None
+        self._slots = []
+        # Hard-coded value until exported by ACME FW via IIO or XMLRPC service
+        self._slots_count = 8
+
+    def is_up(self):
+        return ping(self._ip)
+
+    def get_slot_count(self):
+        self._trace.trace(1, "Slot count: %u" % self._slots_count)
+        return self._slots_count
+
+    def _find_probes(self):
+        acme_server_address = "%s:%d" % (self._ip, 8000)
+
+        # Use ACME XMLRPC service
+        try:
+            proxy = xmlrpclib.ServerProxy("http://%s/acme" % acme_server_address)
+        except:
+            self._trace.trace(1, "Failed to use ACME XMLRPC service! (\"" + acme_server_address + "\")")
+            self._trace.trace(2, traceback.format_exc())
+            return False
+        self._trace.trace(1, "ACME XMLRPC service ready.")
+        # Browse ACME slots one by one to find which ones are populated
+        iio_device_idx = 0
+        for i in range(1, self._slots_count + 1):
+            try:
+                info = proxy.info("%s" % i)
+                self._trace.trace(2, info)
+            except:
+                self._trace.trace(1, "No XMLRPC service found for slot %d." % i)
+                continue
+            if info.find('Failed') != -1:
+                # Slot no used
+                self._trace.trace(1, "XMLRPC: ACME Cape slot %d is empty." % i)
+                self._slots.append(None)
+            else:
+                self._trace.trace(1, "XMLRPC: ACME Cape slot %d is used." % i)
+                # Retrieve probe type
+                if info.find("JACK") != -1:
+                    type = "JACK"
+                elif info.find("USB") != -1:
+                    type = "USB"
+                elif info.find("HE10") != -1:
+                    type = "HE10"
+                else:
+                    self._trace.trace(1, "XMLRPC: probe type not found?!")
+                    self._slots.append(None)
+                    continue
+                self._trace.trace(2, "Probe type: " + type)
+
+                # Retrieve shunt resistor value
+                pos1 = info.find("R_Shunt:")
+                if pos1 != -1:
+                    pos2 = info.find("uOhm")
+                    if pos2 != -1:
+                        shunt = info[pos1 + 9: pos2 - 1]
+                        self._trace.trace(2, "Probe shunt: " + shunt)
+                    else:
+                        self._trace.trace(1, "XMLRPC: probe shunt not found?!")
+                        continue
+                else:
+                    self._trace.trace(1, "XMLRPC: probe shunt not found?!")
+                    continue
+
+                # Retrieve power switch capability
+                if info.find("Has Power Switch") != -1:
+                    pwr_switch = True
+                else:
+                    pwr_switch = False
+                self._trace.trace(2, "Probe power switch: " + str(pwr_switch))
+
+                # Create IIOAcmeProbe instance
+                self._slots.append(IIOAcmeProbe(i, type,
+                                                int(shunt), pwr_switch,
+                                                self._iioctx.devices[iio_device_idx],
+                                                self._verbose_level))
+                iio_device_idx = iio_device_idx + 1
+        return True
+
+    def _show_iio_context_attributes(self):
+        self._trace.trace(3, "======== IIO context infos ========")
+        self._trace.trace(3, "  Name: " + self._iioctx.name)
+        self._trace.trace(3, "  Library version: %u.%u (git tag: %s)" % self._iioctx.version)
+        self._trace.trace(3, "  Backend version: %u.%u (git tag: %s)" % self._iioctx.version)
+        self._trace.trace(3, "  Backend description string: " + self._iioctx.description)
+        if len(self._iioctx.attrs) > 0:
+            self._trace.trace(3, "  Attributes: %u" % len(self._iioctx.attrs))
+            for attr, value in self._iioctx.attrs.items():
+                self._trace.trace(3, "    " + attr + ": " + value)
+        self._trace.trace(3, "===================================")
+
+    def init(self):
+        # Connecting to ACME
+        try:
+            self._trace.trace(1, "Connecting to %s..." % self._ip)
+            self._iioctx = iio.Context("ip:" + self._ip)
+        except OSError as e:
+            self._trace.trace(1, "Connection timed out!")
+            return False
+        except:
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+        if self._verbose_level >= 2:
+            self._show_iio_context_attributes()
+
+        # There is not yet an attribute in the IIO device to indicate in which
+        # ACME Cape slot the IIO device is attached. Hence, need to first find
+        # the populated ACME Cape slot(s), and then save this info.
+        try:
+            self._find_probes()
+        except:
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+        return True
+
+    def probe_is_attached(self, slot):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            if self._slots[slot - 1] is None:
+                self._trace.trace(1, "Slot %d not populated." % slot)
+                return False
+            else:
+                self._trace.trace(1, "Slot %d populated." % slot)
+                return True
+        except:
+            self._trace.trace(1, "Failed to determine slot %d status!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def enable_capture_channel(self, slot, channel, enable):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].enable_capture_channel(channel, enable)
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to configure capture channel (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def set_oversampling_ratio(self, slot, oversampling_ratio):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].set_oversampling_ratio(oversampling_ratio)
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to configure oversampling ratio (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def enable_asynchronous_reads(self, slot, enable):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].enable_asynchronous_reads(enable)
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to configure asynchronous reads (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def get_sampling_frequency(self, slot):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].get_sampling_frequency()
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to retrieve sampling frequency (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def allocate_capture_buffer(self, slot, samples_count, cyclic = False):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].allocate_capture_buffer(samples_count, cyclic)
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to allocate capture buffer (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def refill_capture_buffer(self, slot):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].refill_capture_buffer()
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to refill capture buffer (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def read_capture_buffer(self, slot, channel):
+        # ACME slots are labelled from 1 to 8 on cape, but handle from 0 to 7
+        # in SW
+        try:
+            return self._slots[slot - 1].read_capture_buffer(channel)
+        except AttributeError:
+            self._trace.trace(1, "No probe in slot %d" % slot)
+            return False
+        except:
+            self._trace.trace(1, "Failed to read capture buffer (slot %d)!" % slot)
+            self._trace.trace(2, traceback.format_exc())
+            return False

--- a/pyacmecapture/iioacmeprobe.py
+++ b/pyacmecapture/iioacmeprobe.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python
+""" Python ACME Capture Utility for NXP TPMP (Temperature-controlled Power Measurement Platform)
+
+TBD description of the utility
+
+Inspired by work done on the "iio-capture" tool done by:
+    - Paul Cercueil <paul.cercueil@analog.com>,
+    - Marc Titinger <mtitinger@baylibre.com>,
+    - Fabrice Dreux <fdreux@baylibre.com>,
+and the work done on "pyacmegraph" tool done by:
+    - Sebastien Jan <sjan@baylibre.com>.
+"""
+
+
+from __future__ import print_function
+import iio
+import struct
+import traceback
+import numpy as np
+from mltrace import MLTrace
+
+
+__app_name__ = "IIO ACME Probe Python Library"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018, Baylibre SAS"
+__date__ = "2018/03/01"
+__author__ = "Patrick Titiano"
+__email__ =  "ptitiano@baylibre.com"
+__contact__ = "ptitiano@baylibre.com"
+__maintainer__ = "Patrick Titiano"
+__status__ = "Development"
+__version__ = "0.1"
+__deprecated__ = False
+
+
+# Channels mapping: 'explicit naming' vs 'IIO channel IDs'
+channel_dict = {
+            'Vshunt' : 'voltage0',
+            'Vbat' : 'voltage1',
+            'Time' : 'timestamp',
+            'Ishunt' : 'current3',
+            'Power' : 'power2'}
+
+# Channels unit
+channel_units = {
+            'Vshunt' : 'mV',
+            'Vbat' : 'mV',
+            'Time' : 'ms',
+            'Ishunt' : 'mA',
+            'Power' : 'mW'}
+
+
+class IIOAcmeProbe():
+    def __init__(self, slot, type, shunt, pwr_switch, iio_device, verbose_level):
+        self._slot = slot
+        self._type = type
+        self._shunt = shunt
+        self._pwr_switch = pwr_switch
+        self._iio_device = iio_device
+        self._iio_buffer = None
+        self._verbose_level = verbose_level
+        self._trace = MLTrace(verbose_level, "Probe " + self._type + " Slot " + str(self._slot))
+
+        self._trace.trace(2, "IIOAcmeProbe instance created with settings:")
+        self._trace.trace(2, "Slot: " + str(self._slot) + " Type: " + self._type
+                          + ", Shunt: " + str(self._shunt) + " uOhm" +
+                          ", Power Switch: " + str(self._pwr_switch))
+        if self._verbose_level >= 2:
+            self._show_iio_device_attributes()
+
+    def _show_iio_device_attributes(self):
+        self._trace.trace(3, "======== IIO Device infos ========")
+        self._trace.trace(3, "  ID: " +  self._iio_device.id)
+        self._trace.trace(3, "  Name: " +  self._iio_device.name)
+        if  self._iio_device is iio.Trigger:
+            self._trace.trace(3, "  Trigger: yes (rate: %u Hz)" %  self._iio_device.frequency)
+        else:
+            self._trace.trace(3, "  Trigger: none")
+        self._trace.trace(3, "  Device attributes found: %u" % len( self._iio_device.attrs))
+        for attr in  self._iio_device.attrs:
+            self._trace.trace(3, "    " + attr + ": " +  self._iio_device.attrs[attr].value)
+        self._trace.trace(3, "  Device debug attributes found: %u" % len( self._iio_device.debug_attrs))
+        for attr in  self._iio_device.debug_attrs:
+            self._trace.trace(3, "    " + attr + ": " +  self._iio_device.debug_attrs[attr].value)
+        self._trace.trace(3, "  Device channels found: %u" % len( self._iio_device.channels))
+        for chn in  self._iio_device.channels:
+            self._trace.trace(3, "    Channel ID: %s" % chn.id)
+            self._trace.trace(3, "    Channel name: %s" % "" if chn.name is None else chn.name)
+            self._trace.trace(3, "    Channel direction: %s" % ("output" if chn.output else 'input'))
+            self._trace.trace(3, "    Channel attributes found: %u" % len(chn.attrs))
+            for attr in chn.attrs:
+                    self._trace.trace(3, "      " + attr + ": " + chn.attrs[attr].value)
+            self._trace.trace(3, "")
+        self._trace.trace(2, "==================================")
+
+    def get_slot(self):
+        return self._slot
+
+    def get_type(self):
+        return self._type
+
+    def get_shunt(self):
+        return self._shunt
+
+    def has_power_switch(self):
+        return self._pwr_switch
+
+    def enable_power(self, enable):
+        if self.has_power_switch() == True:
+            if enable == True:
+                #FIXME
+                print("TODO enable power")
+                self._trace.trace(1, "Power enabled.")
+            else:
+                #FIXME
+                print("TODO disable power")
+                self._trace.trace(1, "Power disabled.")
+        else:
+            self._trace.trace(1, "No power switch on this probe!")
+            return False
+        return True
+
+    def set_oversampling_ratio(self, oversampling_ratio):
+        try:
+            self._iio_device.attrs["in_oversampling_ratio"].value = str(oversampling_ratio)
+            self._trace.trace(1, "Oversampling ratio configured to %u." % oversampling_ratio)
+            return True
+        except:
+            self._trace.trace(1, "Failed to configure oversampling ratio (%u)!" % oversampling_ratio)
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def enable_asynchronous_reads(self, enable):
+        try:
+            if enable is True:
+                self._iio_device.attrs["in_allow_async_readout"].value = "1"
+                self._trace.trace(1, "Asynchronous reads enabled.")
+            else:
+                self._iio_device.attrs["in_allow_async_readout"].value = "0"
+                self._trace.trace(1, "Asynchronous reads disabled.")
+            return True
+        except:
+            self._trace.trace(1, "Failed to configure asynchronous reads!")
+            self._trace.trace(2, traceback.format_exc())
+            return False
+
+    def get_sampling_frequency(self):
+        try:
+            freq = self._iio_device.attrs['in_sampling_frequency'].value
+            self._trace.trace(1, "Sampling frequency: %sHz" % freq)
+            return int(freq)
+        except:
+            self._trace.trace(1, "Failed to retrieve sampling frequency!")
+            self._trace.trace(2, traceback.format_exc())
+            return 0
+
+    def enable_capture_channel(self, channel, enable):
+        try:
+            iio_ch = self._iio_device.find_channel(channel_dict[channel])
+            if not (iio_ch):
+                self._trace.trace(1, "Channel %s (%s) not found!" % (channel, channel_dict[channel]))
+                return False
+            self._trace.trace(2, "Channel %s (%s) found." % (channel, channel_dict[channel]))
+            if enable is True:
+                iio_ch.enabled = True
+                self._trace.trace(1, "Channel %s (%s) capture enabled." % (channel, channel_dict[channel]))
+            else:
+                iio_ch.enabled = False
+                self._trace.trace(1, "Channel %s (%s) capture disabled." % (channel, channel_dict[channel]))
+        except:
+            if enable is True:
+                self._trace.trace(1, "Failed to enable capture on channel %s (%s)!")
+            else:
+                self._trace.trace(1, "Failed to disable capture on channel %s (%s)!")
+            self._trace.trace(2, traceback.format_exc())
+            return False
+        return True
+
+    def allocate_capture_buffer(self, samples_count, cyclic = False):
+        self._iio_buffer = iio.Buffer(self._iio_device, samples_count, cyclic)
+        if self._iio_buffer != None:
+            self._trace.trace(1, "Buffer (count=%d, cyclic=%s) allocated." % (samples_count, cyclic))
+            return True
+        else:
+            self._trace.trace(1, "Failed to allocate buffer! (count=%d, cyclic=%s)" % (samples_count, cyclic))
+            return False
+
+    def refill_capture_buffer(self):
+        try:
+            self._iio_buffer.refill()
+        except:
+            self._trace.trace(1, "Failed to refill buffer!")
+            self._trace.trace(2, traceback.format_exc())
+            return False
+        self._trace.trace(1, "Buffer refilled.")
+        return True
+
+    def read_capture_buffer(self, channel):
+        try:
+            # Retrieve channel
+            iio_ch = self._iio_device.find_channel(channel_dict[channel])
+            # Retrieve samples (raw)
+            ch_buf_raw = iio_ch.read(self._iio_buffer)
+            # Unpack binary data to signed integer values
+            unpack_str = 'h' * (len(ch_buf_raw) / struct.calcsize('h'))
+            values = struct.unpack(unpack_str, ch_buf_raw)
+            self._trace.trace(2, "%u samples read." % len(values))
+            self._trace.trace(3, "Samples         : " + str(values))
+            # Scale values
+            scale = float(iio_ch.attrs['scale'].value)
+            self._trace.trace(3, "Scale: %f" % scale)
+            if scale != 1.0:
+                scaled_values = np.asarray(values) * scale
+            else:
+                scaled_values = np.asarray(values)
+            self._trace.trace(3, "Samples (scaled): " + str(scaled_values))
+        except:
+            self._trace.trace(1, "Failed to read channel %s buffer!" % channel)
+            self._trace.trace(2, traceback.format_exc())
+            return None
+        return {"channel": channel, "unit": channel_units[channel], "samples": scaled_values}

--- a/pyacmecapture/mltrace.py
+++ b/pyacmecapture/mltrace.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+""" Multi-Level Trace Python Class
+
+Implement a smart trace with configurable header and debug trace levels.
+
+"""
+
+
+__app_name__ = "Smart Trace Library"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018, Baylibre SAS"
+__date__ = "2018/03/01"
+__author__ = "Patrick Titiano"
+__email__ =  "ptitiano@baylibre.com"
+__contact__ = "ptitiano@baylibre.com"
+__maintainer__ = "Patrick Titiano"
+__status__ = "Development"
+__version__ = "0.1"
+__deprecated__ = False
+
+
+class MLTrace():
+    """Print debug messages depending on selected verbose level.
+
+    Attributes:
+        verbose_level: integer value (> 0) representing the verbose level,
+            usually retrieved from user arguments
+    """
+
+    def __init__(self, verbose_level, msg_header = None):
+        """Init class attribute 'verbose_level'."""
+        self._verbose_level = verbose_level
+        self._msg_header = msg_header
+
+    def trace(self, level, msg):
+        """Print debug messages depending on selected debug level.
+
+        If 'level' <= self.verbose_level, then 'msg' is printed, ignored otherwise.
+
+        Args:
+            level: selected debug level (e.g. 1, 2, 3, ...)
+            msg: a custom message (e.g. 'this is my great custom message')
+        """
+        if (self._verbose_level >= level):
+            if self._msg_header != None:
+                print("[" + self._msg_header + "] " + msg)
+            else:
+                print(msg)

--- a/pyacmecapture/ping.py
+++ b/pyacmecapture/ping.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+    TBD
+"""
+
+
+from platform import system as system_name # Returns the system/OS name
+from os import system as system_call       # Execute a shell command
+
+__app_name__ = ""
+__license__ = ""
+__copyright__ = ""
+__date__ = ""
+__author__ = ""
+__email__ =  ""
+__contact__ = ""
+__maintainer__ = ""
+__status__ = ""
+__version__ = "0.0.1"
+__deprecated__ = False
+
+
+def ping(host):
+    """Return True if host (str) responds to a ping request.
+
+    Send a ping request to 'host' and return True if a response is received,
+    False otherwise.
+    Remember that some hosts may not respond to a ping request even if the host
+    name is valid.
+    Source: https://stackoverflow.com/questions/2953462/pinging-servers-in-python
+
+    Args:
+        host: hostname (e.g. 192.168.1.2 or myhost.mydomain)
+
+    Returns:
+        True if host (str) responds to a ping request, False otherwise.
+    """
+
+    # Ping parameters as function of OS
+    parameters = "-n 1" if system_name().lower() == "windows" else "-c 1"
+
+    # Pinging
+    return system_call("ping " + parameters + " " + host + " > /dev/null") == 0

--- a/pyacmecapture/pyacmecapture.py
+++ b/pyacmecapture/pyacmecapture.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python
+""" Python ACME Power Capture Utility
+
+This utility is designed to capture voltage, current and power samples with
+Baylibre's ACME Power Measurement solution (www.baylibre.com/acme).
+
+The following assumption(s) were made:
+    - ACME Cape slots are populated with probes starting from slot 1,
+      with no 'holes' in between (e.g. populating slots 1,2,3 is valid,
+                                       populating slots 1,2 4 is not)
+
+Inspired by work done on the "iio-capture" tool done by:
+    - Paul Cercueil <paul.cercueil@analog.com>,
+    - Marc Titinger <mtitinger@baylibre.com>,
+    - Fabrice Dreux <fdreux@baylibre.com>,
+and the work done on "pyacmegraph" tool done by:
+    - Sebastien Jan <sjan@baylibre.com>.
+
+Leveraged IIOAcmeCape and IIOAcmeProbe classes abstracting IIO/ACME details.
+
+Todo:
+    * Fix Segmentation fault at end of script
+    * Find a way to remove hard-coded power unit (uW)
+    * Save logs to file
+
+"""
+
+
+from __future__ import print_function
+import sys
+import argparse
+import threading
+import time
+from colorama import init, Fore, Style
+import traceback
+import numpy as np
+from mltrace import MLTrace
+from iioacmecape import IIOAcmeCape
+
+
+__app_name__ = "Python ACME Power Capture Utility"
+__license__ = "MIT"
+__copyright__ = "Copyright 2018, Baylibre SAS"
+__date__ = "2018/03/01"
+__author__ = "Patrick Titiano"
+__email__ =  "ptitiano@baylibre.com"
+__contact__ = "ptitiano@baylibre.com"
+__maintainer__ = "Patrick Titiano"
+__status__ = "Development"
+__version__ = "0.1"
+__deprecated__ = False
+
+
+def log(color, flag, msg):
+    """ Format messages as follow: "['color'ed 'flag'] 'msg'"
+
+    Args:
+        color (str): the color of the flag (e.g. Fore.RED, Fore.GREEN, ...)
+        flag (str): a custom flag (e.g. 'OK', 'FAILED', 'WARNING', ...)
+        msg (str): a custom message (e.g. 'this is my great custom message')
+
+    Returns:
+        None
+
+    """
+    print("[" + color + flag + Style.RESET_ALL + "] " + msg)
+
+
+def exit_with_error(err):
+    """ Display completion message with error code before terminating execution.
+
+    Args:
+        err (int): an error code
+
+    Returns:
+        None
+
+    """
+    if err != 0:
+        print("\nScript execution terminated with error code %d." % err)
+    else:
+        print("\nScript execution completed with success.")
+    print("\n< There will be a 'Segmentation fault (core dumped)' error message after this one. >")
+    print("< This is a kwown bug. Please ignore it. >\n")
+    exit(err)
+
+
+class iioDeviceCaptureThread(threading.Thread):
+    """ IIO ACME Capture thread
+
+    This class is used to abstract the capture of multiple channels of a single
+    ACME probe / IIO device.
+
+    """
+    def __init__(self, threadid, cape, slot, channels, duration, verbose_level):
+        """ Initialise iioDeviceCaptureThread class
+
+        Args:
+            threadid (int): an ID to identify the thread
+            slot (int): ACME cape slot
+            channels (list of strings): channels to capture
+                        Supported channels: 'Vshunt', 'Vbat', 'Ishunt', 'Power'
+            duration (int): capture duration (in seconds)
+            verbose_level (int): how much verbose the debug trace shall be
+
+        Returns:
+            None
+
+        """
+        threading.Thread.__init__(self)
+        # Init internal variables
+        self._threadid = threadid
+        self._cape = cape
+        self._slot = slot
+        self._channels = channels
+        self._duration = duration
+        self._verbose_level = verbose_level
+        self._trace = MLTrace(verbose_level, "Thread #%u (slot #%u)" % (self._threadid, self._slot))
+        self._trace.trace(2, "Thread params: slot=%u channels=%s duration=%us" % (slot, channels, duration))
+
+
+    def configure_capture(self):
+        """ Configure capture parameters (enable channel(s),
+            configure internal settings, ...)
+
+        Args:
+            None
+
+        Returns:
+            bool: True if successful, False otherwise.
+
+        """
+        # Set oversampling for max perfs (4 otherwise)
+        if self._cape.set_oversampling_ratio(self._slot, 1) is False:
+            self._trace.trace(1, "Failed to set oversampling ratio!")
+            return False
+        self._trace.trace(1, "Oversampling ratio set to 1.")
+
+        # Disable asynchronous reads
+        if self._cape.enable_asynchronous_reads(self._slot, False) is False:
+            self._trace.trace(1, "Failed to configure asynchronous reads!")
+            return False
+        self._trace.trace(1, "Asynchronous reads disabled.")
+
+        # Enable selected channels
+        for ch in self._channels:
+            ret = self._cape.enable_capture_channel(self._slot, ch, True)
+            if ret is False:
+                self._trace.trace(1, "Failed to enable %s capture!" % ch)
+                return False
+            else:
+                self._trace.trace(1, "%s capture enabled." % ch)
+
+        # Allocate capture buffer
+        freq = self._cape.get_sampling_frequency(self._slot)
+        if freq == 0:
+            self._trace.trace(1, "Failed to retrieve sampling frequency!")
+            return False
+        self._trace.trace(1, "Sampling frequency: %uHz" % freq)
+        buffer_size = int(freq / 2) # buffer to store 1/2s of samples
+        self._trace.trace(1, "Buffer size: %u" % buffer_size)
+        if self._cape.allocate_capture_buffer(self._slot, buffer_size) is False:
+            self._trace.trace(1, "Failed to allocate %s capture buffer!" % ch)
+            return False
+        else:
+            self._trace.trace(1, "%s capture buffer allocated." % ch)
+        return True
+
+
+    def run(self):
+        """ Start the capture until iioDeviceCaptureThread.stop() is called.
+
+        Args:
+            None
+
+        Returns:
+            None
+
+        """
+        self._alive = True
+        self._failed = False
+        self._samples = {}
+        for ch in self._channels:
+            self._samples[ch] = None
+            self._samples["slot"] = self._slot
+            self._samples["channels"] = self._channels
+            self._samples["duration"] = self._duration
+        while self._alive:
+            # Capture samples
+            ret = self._cape.refill_capture_buffer(self._slot)
+            if ret != True:
+                self._trace.trace(1, "Warning: error during buffer refill!")
+                self._failed = True
+            # Read captured samples
+            for ch in self._channels:
+                s = self._cape.read_capture_buffer(self._slot, ch)
+                if s is None:
+                    self._trace.trace(1, "Warning: error during %s buffer read!" % ch)
+                    self._failed = True
+                if self._samples[ch] is not None:
+                    self._samples[ch]["samples"] = np.append(self._samples[ch]["samples"], s["samples"])
+                else:
+                    self._samples[ch] = {}
+                    self._samples[ch]["failed"] = False
+                    self._samples[ch]["unit"] = s["unit"]
+                    self._samples[ch]["samples"] = s["samples"]
+                self._trace.trace(3, "self._samples[%s] = %s" % (ch, str(self._samples[ch])))
+        self._samples[ch]["failed"] = self._failed
+        self._trace.trace(1, "Thread done.")
+
+
+    def stop(self):
+        """ Stop the capture and return collected samples.
+
+        Args:
+            None
+
+        Returns:
+            A dictionary (one per channel) containing following key/data:
+                "slot" (int): ACME cape slot
+                "channels" (list of strings): channels captured
+                "duration" (int): capture duration (in seconds)
+                For each captured channel:
+                "capture channel name" (dict): a dictionary containing following key/data:
+                    "failed" (bool): False if successful, True otherwise
+                    "samples" (array): captured samples
+                    "unit" (str): captured samples unit}}
+            E.g:
+                {'slot': 1, 'channels': ['Vbat', 'Ishunt'], 'duration': 3,
+                 'Vbat': {'failed': False, 'samples': array([ 1, 2, 3 ]), 'unit': 'mV'},
+                 'Ishunt': {'failed': False, 'samples': array([4, 5, 6 ]), 'unit': 'mA'}}
+
+        """
+        self._alive = False
+        self.join()
+        return self._samples
+
+def main():
+    err = -1
+
+    # Print application header
+    print(__app_name__ + " (version " + __version__ + ")\n")
+
+    # Colorama: reset style to default after each call to print
+    init(autoreset=True)
+
+    # Parse user arguments
+    parser = argparse.ArgumentParser(description='TODO',
+                                     formatter_class=argparse.RawDescriptionHelpFormatter,
+                                     epilog='''
+    This tool captures min, max, and average values of selected power rails (voltage, current, power).
+    These power measurements are performed using Baylibre's ACME cape and probes, over the network using IIO lib.
+    Example usage:
+        ''' + sys.argv[0] + ''' --ip baylibre-acme.local --duration 5 -c 2 -n VDD_1,VDD_2
+
+    Note it is assumed that slots are populated from slot 1 and upwards, with no hole.''')
+    parser.add_argument('--ip', metavar='HOSTNAME', default='baylibre-acme.local',# add default hostname here
+                        help='ACME hostname (e.g. 192.168.1.2 or baylibre-acme.local)')
+    parser.add_argument('--count', '-c', metavar='COUNT', type=int, default=8,
+                        help='Number of power rails to capture (> 0))')
+    parser.add_argument('--names', '-n', metavar='LABELS',
+                        help='''List of names for the captured power rails
+                        (comma separated list, one name per power rail,
+                        always start from ACME Cape slot 1).
+                        E.g. VDD_BAT,VDD_ARM,...''')
+    parser.add_argument('--duration', '-d', metavar='SEC', type=int,
+                        default=10, help='Capture duration in seconds (> 0)')
+    parser.add_argument('--verbose', '-v', action='count',
+                        help='print debug traces (various levels v, vv, vvv)')
+
+    args = parser.parse_args()
+    log(Fore.GREEN, "OK", "Parse user arguments")
+
+    # Use MLTrace to log execution details
+    trace = MLTrace(args.verbose)
+    trace.trace(2, "User args: " + str(args)[10:-1])
+    err = err - 1
+
+    # Create an IIOAcmeCape instance
+    iio_acme_cape = IIOAcmeCape(args.ip, args.verbose)
+    max_rail_count = iio_acme_cape.get_slot_count()
+
+    # Check arguments are valid
+    try:
+        assert (args.count <= max_rail_count)
+        assert (args.count > 0)
+    except:
+        log(Fore.RED, "FAILED", "Check user argument ('count')")
+        exit_with_error(err)
+
+    try:
+        if args.names is not None:
+            args.names = args.names.split(',')
+            trace.trace(2, "args.names: %s" % args.names)
+            assert (args.count == len(args.names))
+    except:
+        log(Fore.RED, "FAILED", "Check user argument ('names')")
+        exit_with_error(err)
+
+    try:
+        assert (args.duration > 0)
+    except:
+        log(Fore.RED, "FAILED", "Check user argument ('duration')")
+        exit_with_error(err)
+    err = err - 1
+    log(Fore.GREEN, "OK", "Check user arguments")
+
+    # Check ACME Cape is reachable
+    if iio_acme_cape.is_up() != True:
+        log(Fore.RED, "FAILED", "Ping ACME")
+        exit_with_error(err)
+    log(Fore.GREEN, "OK", "Ping ACME")
+    err = err - 1
+
+    # Init IIOAcmeCape instance
+    if (iio_acme_cape.init() != True):
+        log(Fore.RED, "FAILED", "Init ACME IIO Context")
+        exit_with_error(err)
+    log(Fore.GREEN, "OK", "Init ACME Cape instance")
+    err = err - 1
+
+    # Check all probes are attached
+    failed = False
+    for i in range(1, args.count + 1):
+        attached = iio_acme_cape.probe_is_attached(i)
+        if attached is not True:
+            log(Fore.RED, "FAILED", "Detect probe in slot %u" % i)
+            failed = True
+        else:
+            log(Fore.GREEN, "OK", "Detect probe in slot %u" % i)
+    if failed is True:
+        exit_with_error(err)
+    err = err - 1
+
+    # Create and configure capture threads
+    threads = []
+    failed = False
+    for i in range(1, args.count + 1):
+        try:
+            thread = iioDeviceCaptureThread(i, iio_acme_cape,
+                                            i, ["Vbat", "Ishunt"], args.duration, args.verbose)
+            thread.configure_capture()
+            threads.append(thread)
+            log(Fore.GREEN, "OK", "Configure capture thread for probe in slot #%u" % i)
+        except:
+            log(Fore.RED, "FAILED", "Configure capture thread for probe in slot #%u" % i)
+            trace.trace(2, traceback.format_exc())
+            exit_with_error(err)
+    err = err - 1
+
+    # Start capture threads
+    try:
+        for thread in threads:
+            thread.start()
+    except:
+        log(Fore.RED, "FAILED", "Start capture")
+        trace.trace(2, traceback.format_exc())
+        exit_with_error(err)
+    log(Fore.GREEN, "OK", "Start capture")
+    err = err - 1
+
+    # Sleep
+    time.sleep(args.duration)
+
+    # Stop capture threads an retrieve captured data
+    slot = 0
+    captured_data = []
+    for thread in threads:
+        captured_data.append(thread.stop())
+        trace.trace(3, "Slot %u captured data: %s" % (slot + 1, captured_data[slot]))
+        slot = slot + 1
+    log(Fore.GREEN, "OK", "Stop capture")
+
+    # Process samples
+    for i in range(1, args.count + 1):
+        slot = captured_data[i - 1]["slot"]
+        vbat_samples = captured_data[i - 1]["Vbat"]["samples"]
+        ishunt_samples = captured_data[i - 1]["Ishunt"]["samples"]
+        # Compute P (P = Vbat * Ishunt)
+        captured_data[i - 1]["P"] = {}
+        captured_data[i - 1]["P"]["unit"] = "uW" # FIXME
+        captured_data[i - 1]["P"]["samples"] = np.multiply(vbat_samples, ishunt_samples)
+        p_samples = captured_data[i - 1]["P"]["samples"]
+        trace.trace(3, "Slot %u power samples: %s" % (slot, p_samples))
+
+        # Compute min, max, avg values for Vbat, Ishunt and P
+        vbat_min = captured_data[i - 1]["Vbat min"] = np.amin(vbat_samples)
+        vbat_max = captured_data[i - 1]["Vbat max"] = np.amax(vbat_samples)
+        vbat_avg = captured_data[i - 1]["Vbat avg"] = np.average(vbat_samples)
+        ishunt_min = captured_data[i - 1]["Ishunt min"] = np.amin(ishunt_samples)
+        ishunt_max = captured_data[i - 1]["Ishunt max"] = np.amax(ishunt_samples)
+        ishunt_avg = captured_data[i - 1]["Ishunt avg"] = np.average(ishunt_samples)
+        p_min = captured_data[i - 1]["P min"] = np.amin(p_samples)
+        p_max = captured_data[i - 1]["P max"] = np.amax(p_samples)
+        p_avg = captured_data[i - 1]["P avg"] = np.average(p_samples)
+    log(Fore.GREEN, "OK", "Process samples")
+
+    # Save data to file and display report
+    print("\n------------------ Measurement results ------------------")
+    print("Power Rails: %u" % args.count)
+    print("Duration: %us" % args.duration)
+    for i in range(1, args.count + 1):
+        if args.names is not None:
+            print("%s (slot %u)" % (args.names[i - 1], i))
+        else:
+            print("Slot %u" % i)
+        vbat_min = captured_data[i - 1]["Vbat min"]
+        vbat_max = captured_data[i - 1]["Vbat max"]
+        vbat_avg = captured_data[i - 1]["Vbat avg"]
+        unit = captured_data[i - 1]["Vbat"]["unit"]
+        print("  Voltage (%s): min=%d max=%d avg=%d" % (unit, vbat_min, vbat_max, vbat_avg))
+        ishunt_min = captured_data[i - 1]["Ishunt min"]
+        ishunt_max = captured_data[i - 1]["Ishunt max"]
+        ishunt_avg = captured_data[i - 1]["Ishunt avg"]
+        unit = captured_data[i - 1]["Ishunt"]["unit"]
+        print("  Current (%s): min=%d max=%d avg=%d" % (unit, ishunt_min, ishunt_max, ishunt_avg))
+        p_min = captured_data[i - 1]["P min"]
+        p_max = captured_data[i - 1]["P max"]
+        p_avg = captured_data[i - 1]["P avg"]
+        unit = captured_data[i - 1]["P"]["unit"]
+        print("  Power   (%s): min=%d max=%d avg=%d" % (unit, p_min, p_max, p_avg))
+        if i != args.count:
+            print()
+    print("---------------------------------------------------------")
+    exit_with_error(0)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
First version of the pyacmecapture utility.
This command-line utility is designed to capture voltage,
current and power samples with ACME.

```
$ ./pyacmecapture.py --ip baylibre-acme.local -d 3 -c 1 -n VDD_1
Python ACME Power Capture Utility (version 0.1)

[OK] Parse user arguments
[OK] Check user arguments
[OK] Ping ACME
[OK] Init ACME Cape instance
[OK] Detect probe in slot 1
[OK] Configure capture thread for probe in slot #1
[OK] Start capture
[OK] Stop capture
[OK] Process samples

------------------ Measurement results ------------------
Power Rails: 1
Duration: 3s
VDD_1 (slot 1)
  Voltage (mV): min=12035 max=12048 avg=12042
  Current (mA): min=227 max=228 avg=227
  Power   (uW): min=2731945 max=2747115 avg=2741051
---------------------------------------------------------

Script execution completed with success.
```